### PR TITLE
fix: need to spread the object otherwise you loose the config

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -38,7 +38,7 @@ export class TopologyNode {
       };
     } 
     if(!this._config.network_config?.tslog_config){
-      this._config.network_config = { tslog_config: this._config?.tslog_config };
+      this._config.network_config = { ...this._config.network_config, tslog_config: this._config?.tslog_config };
     }
     this.networkNode = new TopologyNetworkNode(this._config?.network_config);
     this._objectStore = new TopologyObjectStore();


### PR DESCRIPTION
We need to spread the object otherwise you'll loose the config assign before