### PR TITLE
refactor: reuse protobuf Vertex definition

### DIFF
--- a/packages/blueprints/src/AddWinsSet/index.ts
+++ b/packages/blueprints/src/AddWinsSet/index.ts
@@ -44,9 +44,12 @@ export class AddWinsSet<T> implements CRO {
 
 	// in this case is an array of length 2 and there are only two possible operations
 	resolveConflicts(vertices: Vertex[]): ResolveConflictsType {
+		// Both must have operations, if not return no-op
 		if (
-			vertices[0].operation.type !== vertices[1].operation.type &&
-			vertices[0].operation.value === vertices[1].operation.value
+			vertices[0].operation &&
+			vertices[1].operation &&
+			vertices[0].operation?.type !== vertices[1].operation?.type &&
+			vertices[0].operation?.value === vertices[1].operation?.value
 		) {
 			return vertices[0].operation.type === "add"
 				? { action: ActionType.DropRight }

--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -83,13 +83,13 @@ export class HashGraph {
 	 * @param operation - The operation to be added
 	 * @returns The vertex that was added, with the operation being defined rather than undefined.
 	 */
-	addToFrontier(operation: Operation): Omit<Vertex, "operation"> & { operation: Operation } {
+	addToFrontier(operation: Operation): Vertex {
 		const deps = this.getFrontier();
 		const hash = computeHash(this.nodeId, operation, deps);
 		const vertex = {
 			hash,
 			nodeId: this.nodeId,
-			operation,
+			operation ?? { type: OperationType.NOP },
 			dependencies: deps,
 		};
 

--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -9,7 +9,7 @@ export { Vertex, Operation };
 
 export type Hash = string;
 
-enum OperationType {
+export enum OperationType {
 	NOP = "-1",
 }
 
@@ -79,17 +79,14 @@ export class HashGraph {
 		this.forwardEdges.set(HashGraph.rootHash, []);
 	}
 
-	/**
-	 * @param operation - The operation to be added
-	 * @returns The vertex that was added, with the operation being defined rather than undefined.
-	 */
 	addToFrontier(operation: Operation): Vertex {
 		const deps = this.getFrontier();
 		const hash = computeHash(this.nodeId, operation, deps);
-		const vertex = {
+
+		const vertex: Vertex = {
 			hash,
 			nodeId: this.nodeId,
-			operation ?? { type: OperationType.NOP },
+			operation: operation ?? { type: OperationType.NOP },
 			dependencies: deps,
 		};
 

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -87,7 +87,6 @@ export class TopologyObject implements ITopologyObject {
 
 	// biome-ignore lint: value can't be unknown because of protobuf
 	callFn(fn: string, args: any) {
-		// Since we are creating a vertex with known values, the operation should not be undefined.
 		const vertex = this.hashGraph.addToFrontier({ type: fn, value: args });
 		const serializedVertex = ObjectPb.Vertex.create({
 			hash: vertex.hash,
@@ -104,7 +103,7 @@ export class TopologyObject implements ITopologyObject {
 
 	merge(vertices: Vertex[]) {
 		for (const vertex of vertices) {
-			// Vertex operation is expected to be defined, if its not defined we ignore it and continue.
+			// Check to avoid manually crafted `undefined` operations
 			if (!vertex.operation) {
 				continue;
 			}
@@ -118,7 +117,6 @@ export class TopologyObject implements ITopologyObject {
 
 		const operations = this.hashGraph.linearizeOperations();
 		this.vertices = this.hashGraph.getAllVertices().map((vertex) => {
-			// Again, we are filtering out vertices with undefined operations.
 			if (!vertex.operation) {
 				return;
 			}

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -2,7 +2,6 @@ import * as crypto from "node:crypto";
 import {
 	HashGraph,
 	type Operation,
-	OperationType,
 	type ResolveConflictsType,
 	type SemanticsType,
 	type Vertex,
@@ -91,7 +90,7 @@ export class TopologyObject implements ITopologyObject {
 		const serializedVertex = ObjectPb.Vertex.create({
 			hash: vertex.hash,
 			nodeId: vertex.nodeId,
-			operation: vertex.operation ?? { type: OperationType.NOP },
+			operation: vertex.operation,
 			dependencies: vertex.dependencies,
 		});
 		this.vertices.push(serializedVertex);
@@ -113,17 +112,7 @@ export class TopologyObject implements ITopologyObject {
 		}
 
 		const operations = this.hashGraph.linearizeOperations();
-		this.vertices = this.hashGraph
-			.getAllVertices()
-			.filter((vertex) => vertex.operation !== undefined)
-			.map((vertex) => {
-				return {
-					hash: vertex.hash,
-					nodeId: vertex.nodeId,
-					operation: vertex.operation,
-					dependencies: vertex.dependencies,
-				};
-			});
+		this.vertices = this.hashGraph.getAllVertices();
 
 		(this.cro as CRO).mergeCallback(operations);
 		this._notify("merge", this.vertices);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,16 +45,16 @@ importers:
   examples/canvas:
     dependencies:
       '@topology-foundation/blueprints':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/blueprints
       '@topology-foundation/network':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/network
       '@topology-foundation/node':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/node
       '@topology-foundation/object':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/object
       crypto-browserify:
         specifier: ^3.12.0
@@ -91,16 +91,16 @@ importers:
   examples/chat:
     dependencies:
       '@topology-foundation/blueprints':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/blueprints
       '@topology-foundation/network':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/network
       '@topology-foundation/node':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/node
       '@topology-foundation/object':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/object
       assemblyscript:
         specifier: ^0.27.29
@@ -146,13 +146,13 @@ importers:
   examples/grid:
     dependencies:
       '@topology-foundation/network':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/network
       '@topology-foundation/node':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/node
       '@topology-foundation/object':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../../packages/object
       assemblyscript:
         specifier: ^0.27.29
@@ -205,7 +205,7 @@ importers:
         version: 4.0.3
     devDependencies:
       '@topology-foundation/object':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../object
       assemblyscript:
         specifier: ^0.27.29
@@ -305,13 +305,13 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       '@topology-foundation/blueprints':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../blueprints
       '@topology-foundation/network':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../network
       '@topology-foundation/object':
-        specifier: 0.1.1
+        specifier: 0.2.0
         version: link:../object
       commander:
         specifier: ^12.1.0


### PR DESCRIPTION
Re-use exisiting protobuf Vertex definition for `packages/object`, removing the need to maintain a separate TS typedef. This is done by re-exporting the protobuf-gen typedef with the same name.

Since protobuf makes its message field optional by default since proto3, to address the undefined warning, a few modification is done:

1. `addToFrontier` now returns a Vertex with a defined `operation` field.
2. `merge` now ignores vertex with an undefined operation field. Alternatively we can make `merge` throw or log an error when vertex with undefined operation is received.

Closes #151.